### PR TITLE
Put whitespace before http to prevent colorizing issues

### DIFF
--- a/krill/krill.py
+++ b/krill/krill.py
@@ -208,6 +208,7 @@ class Application:
 
             # Put a space before http to separate things better
             excerpt = re.sub(r"(\S){1}http", r"\1 http", excerpt)
+            excerpt = re.sub(r"(\S){1}pic.twitter.com", r"\1 pic.twitter.com", excerpt)
 
             # Hashtag or mention
             excerpt = re.sub("(?<!\w)([#@])(\w+)",

--- a/krill/krill.py
+++ b/krill/krill.py
@@ -206,6 +206,9 @@ class Application:
             excerpter = TextExcerpter()
             excerpt, clipped_left, clipped_right = excerpter.get_excerpt(item.text, 220, pattern)
 
+            # Put a space before http to separate things better
+            excerpt = re.sub(r"(\S){1}http", r"\1 http", excerpt)
+
             # Hashtag or mention
             excerpt = re.sub("(?<!\w)([#@])(\w+)",
                              term.green("\\g<1>") + term.bright_green("\\g<2>"), excerpt)


### PR DESCRIPTION
Sometimes hashtags will be smashed into links. When the `_print_stream_item` regex tried to put in
the colorings, the escape codes were being inserted after the : in the link. This commit will put
a space before http (if there's a character in front of it).

Example before:
![image](https://cloud.githubusercontent.com/assets/344995/26276565/eaa434b0-3d47-11e7-9414-4929f6b32e6f.png)

And after:
![image](https://cloud.githubusercontent.com/assets/344995/26276572/fb0e39fe-3d47-11e7-8294-5289b1bc2a6d.png)

